### PR TITLE
Added documentation on how to contribute to medusa

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,4 +22,4 @@ source scripts/.env
 Now you can open Vault in a browser [https://localhost:8201](https://localhost:8201) and login with the root token (found by `echo $VAULT_TOKEN`)
 
 ## How to contribute
-Create an issue or pull request
+Please read and follow our [contributing guide](docs/CONTRIBUTING.md)

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,30 @@
+# Contributing to Medusa
+
+Thank you so much for contributing to Medusa. We appreciate your time and help.
+Here are some guidelines to help you get started.
+
+## Code of Conduct
+
+Be kind and respectful to the members of the community. Take time to educate
+others who are seeking help. Harassment of any kind will not be tolerated.
+
+## Questions
+
+If you have questions regarding Medusa, feel free to create an issue with your question in the repository
+
+## Filing a bug or feature
+
+1. Before filing an issue, please check the existing issues to see if a similar one was already opened. If there is one already opened, feel free to comment on it.
+1. If you believe you've found a bug, please provide detailed steps of reproduction, the version of Medusa and anything else you believe will be useful to help troubleshoot it (e.g. OS environment, environment variables, etc...). Also state the current behavior vs. the expected behavior.
+1. If you'd like to see a feature or an enhancement please open an issue with a clear title and description of what the feature is and why it would be beneficial to the project and its users.
+
+### Quick steps to contribute
+
+1. Fork the project.
+1. Download your fork to your PC (`git clone https://github.com/your_username/medusa && cd medusa`)
+1. Create your feature branch (`git checkout -b my-new-feature`)
+1. Make changes and run tests (`make test`)
+1. Add them to staging (`git add .`)
+1. Commit your changes (`git commit -m 'Add some feature'`)
+1. Push to the branch (`git push origin my-new-feature`)
+1. Create new pull request


### PR DESCRIPTION
I've documented how to contribute to Medusa and linked to the contribution page from the main README.md

Only question is if it belong in the docs folder, or it should be in the root and called CONTRIBUTION.md . I dont know if that is a standard. 

This solves #2 