### PR TITLE
Fixed typo in long cmd description, and example output

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Go learn how to use the various commands, check out [quick-guide](docs/quick-gui
 To test out `medusa` on your laptop
 ```
 Medusa is a cli tool currently for importing a json or yaml file into HashiCorp Vault.
-Created by by Jonas Vinther & Henrik Høegh.
+Created by Jonas Vinther & Henrik Høegh.
 
 Usage:
   medusa [command]

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -11,7 +11,7 @@ var rootCmd = &cobra.Command{
 	Use:   "medusa",
 	Short: "Medusa is a cli tool currently for importing a json or yaml file into HashiCorp Vault.",
 	Long: `Medusa is a cli tool currently for importing a json or yaml file into HashiCorp Vault.
-Created by by Jonas Vinther & Henrik Høegh.`,
+Created by Jonas Vinther & Henrik Høegh.`,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		// Apply the viper config value to the flag when the flag is not set and viper has a value
 		address, _ := cmd.Flags().GetString("address")


### PR DESCRIPTION
New output example fixed by hand, not verified by running the updated code.