### PR TITLE
Fix kv1 exports: infix + data format

### DIFF
--- a/pkg/vaultengine/folder_read.go
+++ b/pkg/vaultengine/folder_read.go
@@ -9,7 +9,7 @@ func (client *Client) FolderRead(path string) ([]interface{}, error) {
 	infix := "/metadata/"
 
 	if client.engineType == "kv1" {
-		infix = ""
+		infix = "/"
 	}
 
 	finalPath := client.engine + infix + path

--- a/pkg/vaultengine/secret_read.go
+++ b/pkg/vaultengine/secret_read.go
@@ -23,10 +23,14 @@ func (client *Client) SecretRead(path string) map[string]interface{} {
 		log.Fatalf("No secret found using path [%s] on Vault instance [%s]. Medusa will terminate now.", path, client.addr)
 	}
 
-	m, ok := secret.Data["data"].(map[string]interface{})
-	if !ok {
-		log.Fatalf("Error while reading secret\nPath:\t%s\nData:\t%#v\n\n", finalPath, secret.Data["data"])
-	}
+	if client.engineType == "kv1" {
+		return secret.Data
+	} else {
+		m, ok := secret.Data["data"].(map[string]interface{})
+		if !ok {
+			log.Fatalf("Error while reading secret\nPath:\t%s\nData:\t%#v\n\n", finalPath, secret.Data["data"])
+		}
 
-	return m
+		return m
+	}
 }


### PR DESCRIPTION
Hi!

I've made a couple of fixes to the kv1 export code:

- The separator between the engine and the path must be a slash in FolderRead, same as in SecretRead (#44).
- The format of the data returned from secrets is different -- the "data" field is only present in kv2 engines, the kv1 ones return the key-value pairs directly.

I've tried this changes with my Vault instance and it seems to work fine with both kv1 and kv2 engines (previously, the kv1 failed because the `secret.Data["data"]` field does not exist).

I hope this is useful. Thanks a lot for your work!