### PR TITLE
Export secrets located elsewhere than in leaves (#56)

### DIFF
--- a/pkg/vaultengine/folder_export.go
+++ b/pkg/vaultengine/folder_export.go
@@ -69,6 +69,11 @@ func (client *Client) pathReader(parentFolder *Folder, path string) error {
 				return err
 			}
 
+			if (*parentFolder)[keyName] != nil {
+				for key, elem := range (*parentFolder)[keyName].(map[string]interface{}) {
+					subFolder[key] = elem
+			    }
+            }
 			(*parentFolder)[keyName] = subFolder
 		} else {
 			s := client.SecretRead(newPath)


### PR DESCRIPTION
 - Before secret at foo/bar got overwritten with secret at
   foo/bar/moo
 - Still if key of secret is equal to an path of an other secret,
   the key is overwritten e.g. pw=value at foo/bar is overwritten
   by secrets at foo/bar/pw. I believe this can't be solved if
   using yaml or json export formats