### PR TITLE
Added parameter to support namespaces

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -41,15 +41,6 @@ Created by Jonas Vinther & Henrik Høegh.`,
 			}
 		}
 
-		namespace, _ := cmd.Flags().GetString("namespace")
-		if viper.IsSet("VAULT_NAMESPACE") && namespace == "" {
-			value := viper.Get("VAULT_NAMESPACE").(string)
-			err := cmd.Flags().Set("namespace", value)
-			if err != nil {
-				return err
-			}
-		}		
-
 		return nil
 	},
 }
@@ -63,7 +54,6 @@ func init() {
 	rootCmd.PersistentFlags().StringP("address", "a", "", "Address of the Vault server")
 	rootCmd.PersistentFlags().StringP("token", "t", "", "Vault authentication token")
 	rootCmd.PersistentFlags().BoolP("insecure", "k", false, "Allow insecure server connections when using SSL")
-	rootCmd.PersistentFlags().StringP("namespace", "n", "", "Namespace within the Vault server (Enterprise only)")
 
 	// AutomaticEnv makes Viper load environment variables
 	viper.AutomaticEnv()

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -41,6 +41,15 @@ Created by Jonas Vinther & Henrik Høegh.`,
 			}
 		}
 
+		namespace, _ := cmd.Flags().GetString("namespace")
+		if viper.IsSet("VAULT_NAMESPACE") && namespace == "" {
+			value := viper.Get("VAULT_NAMESPACE").(string)
+			err := cmd.Flags().Set("namespace", value)
+			if err != nil {
+				return err
+			}
+		}		
+
 		return nil
 	},
 }
@@ -54,6 +63,7 @@ func init() {
 	rootCmd.PersistentFlags().StringP("address", "a", "", "Address of the Vault server")
 	rootCmd.PersistentFlags().StringP("token", "t", "", "Vault authentication token")
 	rootCmd.PersistentFlags().BoolP("insecure", "k", false, "Allow insecure server connections when using SSL")
+	rootCmd.PersistentFlags().StringP("namespace", "n", "", "Namespace within the Vault server (Enterprise only)")
 
 	// AutomaticEnv makes Viper load environment variables
 	viper.AutomaticEnv()

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -41,6 +41,15 @@ Created by Jonas Vinther & Henrik Høegh.`,
 			}
 		}
 
+		namespace, _ := cmd.Flags().GetString("namespace")
+		if viper.IsSet("VAULT_NAMESPACE") && namespace == "" {
+			value := viper.Get("VAULT_NAMESPACE").(string)
+			err := cmd.Flags().Set("namespace", value)
+			if err != nil {
+				return err
+			}
+		}
+
 		return nil
 	},
 }
@@ -54,6 +63,7 @@ func init() {
 	rootCmd.PersistentFlags().StringP("address", "a", "", "Address of the Vault server")
 	rootCmd.PersistentFlags().StringP("token", "t", "", "Vault authentication token")
 	rootCmd.PersistentFlags().BoolP("insecure", "k", false, "Allow insecure server connections when using SSL")
+	rootCmd.PersistentFlags().StringP("namespace", "n", "", "Namespace within the Vault server (Enterprise only)")
 
 	// AutomaticEnv makes Viper load environment variables
 	viper.AutomaticEnv()

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -28,13 +28,14 @@ var exportCmd = &cobra.Command{
 		vaultAddr, _ := cmd.Flags().GetString("address")
 		vaultToken, _ := cmd.Flags().GetString("token")
 		insecure, _ := cmd.Flags().GetBool("insecure")
+		namespace, _ := cmd.Flags().GetString("namespace")
 		engineType, _ := cmd.Flags().GetString("engine-type")
 		doEncrypt, _ := cmd.Flags().GetBool("encrypt")
 		exportFormat, _ := cmd.Flags().GetString("format")
 		output, _ := cmd.Flags().GetString("output")
 
 		engine, path := vaultengine.PathSplitPrefix(path)
-		client := vaultengine.NewClient(vaultAddr, vaultToken, insecure)
+		client := vaultengine.NewClient(vaultAddr, vaultToken, insecure, namespace)
 		client.UseEngine(engine)
 		client.SetEngineType(engineType)
 

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -28,14 +28,13 @@ var exportCmd = &cobra.Command{
 		vaultAddr, _ := cmd.Flags().GetString("address")
 		vaultToken, _ := cmd.Flags().GetString("token")
 		insecure, _ := cmd.Flags().GetBool("insecure")
-		namespace, _ := cmd.Flags().GetString("namespace")
 		engineType, _ := cmd.Flags().GetString("engine-type")
 		doEncrypt, _ := cmd.Flags().GetBool("encrypt")
 		exportFormat, _ := cmd.Flags().GetString("format")
 		output, _ := cmd.Flags().GetString("output")
 
 		engine, path := vaultengine.PathSplitPrefix(path)
-		client := vaultengine.NewClient(vaultAddr, vaultToken, insecure, namespace)
+		client := vaultengine.NewClient(vaultAddr, vaultToken, insecure)
 		client.UseEngine(engine)
 		client.SetEngineType(engineType)
 

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -28,13 +28,12 @@ var importCmd = &cobra.Command{
 		vaultAddr, _ := cmd.Flags().GetString("address")
 		vaultToken, _ := cmd.Flags().GetString("token")
 		insecure, _ := cmd.Flags().GetBool("insecure")
-		namespace, _ := cmd.Flags().GetString("namespace")
 		engineType, _ := cmd.Flags().GetString("engine-type")
 		doDecrypt, _ := cmd.Flags().GetBool("decrypt")
 		privateKey, _ := cmd.Flags().GetString("private-key")
 
 		engine, prefix := vaultengine.PathSplitPrefix(path)
-		client := vaultengine.NewClient(vaultAddr, vaultToken, insecure, namespace)
+		client := vaultengine.NewClient(vaultAddr, vaultToken, insecure)
 		client.UseEngine(engine)
 		client.SetEngineType(engineType)
 

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -28,12 +28,13 @@ var importCmd = &cobra.Command{
 		vaultAddr, _ := cmd.Flags().GetString("address")
 		vaultToken, _ := cmd.Flags().GetString("token")
 		insecure, _ := cmd.Flags().GetBool("insecure")
+		namespace, _ := cmd.Flags().GetString("namespace")
 		engineType, _ := cmd.Flags().GetString("engine-type")
 		doDecrypt, _ := cmd.Flags().GetBool("decrypt")
 		privateKey, _ := cmd.Flags().GetString("private-key")
 
 		engine, prefix := vaultengine.PathSplitPrefix(path)
-		client := vaultengine.NewClient(vaultAddr, vaultToken, insecure)
+		client := vaultengine.NewClient(vaultAddr, vaultToken, insecure, namespace)
 		client.UseEngine(engine)
 		client.SetEngineType(engineType)
 

--- a/pkg/vaultengine/vaultclient.go
+++ b/pkg/vaultengine/vaultclient.go
@@ -16,12 +16,11 @@ type Client struct {
 }
 
 // NewClient creates a instance of the VaultClient struct
-func NewClient(addr, token string, insecure bool, namespace string) *Client {
+func NewClient(addr, token string, insecure bool) *Client {
 	client := &Client{
 		token:    token,
 		addr:     addr,
-		insecure: insecure,
-		namespace: namespace}
+		insecure: insecure}
 
 	client.newVaultClient()
 
@@ -53,9 +52,9 @@ func (client *Client) newVaultClient() error {
 
 	client.vc = vc
 
-	if client.namespace != "" {
-		client.vc.SetNamespace(client.namespace)
-	}
+	// if client.namespace != "" {
+	// 	client.vc.SetNamespace(client.namespace)
+	// }
 
 	if client.token != "" {
 		client.vc.SetToken(client.token)

--- a/pkg/vaultengine/vaultclient.go
+++ b/pkg/vaultengine/vaultclient.go
@@ -16,11 +16,12 @@ type Client struct {
 }
 
 // NewClient creates a instance of the VaultClient struct
-func NewClient(addr, token string, insecure bool) *Client {
+func NewClient(addr, token string, insecure bool, namespace string) *Client {
 	client := &Client{
 		token:    token,
 		addr:     addr,
-		insecure: insecure}
+		insecure: insecure,
+		namespace: namespace}
 
 	client.newVaultClient()
 
@@ -52,9 +53,9 @@ func (client *Client) newVaultClient() error {
 
 	client.vc = vc
 
-	// if client.namespace != "" {
-	// 	client.vc.SetNamespace(client.namespace)
-	// }
+	if client.namespace != "" {
+		client.vc.SetNamespace(client.namespace)
+	}
 
 	if client.token != "" {
 		client.vc.SetToken(client.token)


### PR DESCRIPTION
An additional command line paramater "-n" is supported to pass a namespace to the vault client (for Enterprise licensed Vaults)