### PR TITLE
go.mod: Fix module path to match best practices

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module medusa
+module github.com/jonasvinther/medusa
 
 go 1.13
 


### PR DESCRIPTION
https://golang.org/doc/modules/gomod-ref#module-notes

`go install` currently fails with:

```
go install: github.com/jonasvinther/medusa@latest: github.com/jonasvinther/medusa@v0.2.5: parsing go.mod:
	module declares its path as: medusa
	        but was required as: github.com/jonasvinther/medusa
```