### PR TITLE
queries to kv1 should return path variable not string

### DIFF
--- a/pkg/vaultengine/vaultclient.go
+++ b/pkg/vaultengine/vaultclient.go
@@ -47,7 +47,7 @@ func (client *Client) MountpathSplitPrefix(path string) (string, string, error) 
 	if err != nil {
 		// any 404 indicates k/v v1
 		if resp != nil && resp.StatusCode == 404 {
-			return "", "path", nil
+			return "", path, nil
 		}
 		return "", "", err
 	}


### PR DESCRIPTION
Currently if the API is determined to be kv1 the path is always set to the string
"path", whereas it should be set to the value of the variable passed in.

Closes #78