### PR TITLE
Add: Decrypt an exported incrypted file

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
   * [Importing secrets](#importing-secrets)
   * [Exporting secrets](#exporting-secrets)
   * [Deleting secrets](#deleting-secrets)
+  * [Decrypt secrets](#decrypt-secrets)
   * [Kubernetes examples](docs/examples/kubernetes/cronjob/)
   * [Docker examples](docs/examples/docker/)
 - [Secure secret management outside Vault](#secure-secret-management-outside-vault)
@@ -197,6 +198,32 @@ Deleting secret [secret/staging/users/cart/database/users/writeuser]
 Deleting secret [secret/staging/users/user/database]
 Deleting secret [secret/staging/users/user/database/users/readuser]
 The secrets has now been deleted
+```
+
+### Decrypt secrets
+> Get help with `./medusa decrypt -h`
+Medusa decrypt will take a [FILE path] with [flags]
+
+```
+  Flags:
+  -p, --private-key string   Location of the RSA private key
+```
+
+Example:
+```
+# Write to stdout
+./medusa decrypt encrypted-export.txt --private-key private-key.pem
+env:
+  dev:
+    nomad:
+      token: secret-token
+  production:
+    nomad:
+      token: secret-other-token
+
+
+# Write to file
+./medusa decrypt encrypted-export.txt --private-key private-key.pem > plaintext-export.yaml
 ```
 
 ## Secure secret management outside Vault

--- a/cmd/decrypt.go
+++ b/cmd/decrypt.go
@@ -1,0 +1,34 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/jonasvinther/medusa/pkg/encrypt"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(decryptCmd)
+	decryptCmd.PersistentFlags().StringP("private-key", "p", "", "Location of the RSA private key")
+}
+
+var decryptCmd = &cobra.Command{
+	Use:   "decrypt [file path] [flags]",
+	Short: "Decrypt an encrypted Vault output file into plaintext in stdout",
+	Long:  ``,
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		file := args[0]
+		privateKey, _ := cmd.Flags().GetString("private-key")
+
+		decryptedData, err := encrypt.Decrypt(privateKey, file)
+		if err != nil {
+			fmt.Println(err)
+			return err
+		}
+
+		fmt.Printf("%s", decryptedData)
+
+		return nil
+	},
+}


### PR DESCRIPTION
This PR will add a new command to medusa that will allow Medusa to decrypt an exported incypted file into plain text.
This feature is requested in issue #90.