### PR TITLE
Add an encrypt command

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,26 @@ env:
 ./medusa decrypt encrypted-export.txt --private-key private-key.pem > plaintext-export.yaml
 ```
 
+### Encrypt secrets
+> Get help with `./medusa encrypt -h`
+Medusa encrypt will take a [FILE path] with [flags]
+
+```
+  Flags:
+  -o, --output string       Write to file instead of stdout
+  -p, --public-key string   Location of the RSA public key
+```
+
+Example:
+```
+# Write to stdout
+./medusa encrypt plaintext-export.txt --public-key public-key.pem
+&lt;Encrypted data&gt;
+
+# Write to file
+./medusa encrypt plaintext-export.txt --public-key public-key.pem --output encrypted-export.txt.b64
+```
+
 ## Secure secret management outside Vault
 Medusa will help you securely manage your secrets outside Vault.
 This could for instance be as a backup of your Vault data or while your secrets are being transported between Vault instances.  

--- a/cmd/encrypt.go
+++ b/cmd/encrypt.go
@@ -1,0 +1,63 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/jonasvinther/medusa/pkg/encrypt"
+	"github.com/jonasvinther/medusa/pkg/vaultengine"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(encryptCmd)
+	encryptCmd.PersistentFlags().StringP("output", "o", "", "Write to file instead of stdout")
+	encryptCmd.PersistentFlags().StringP("public-key", "p", "", "Location of the RSA public key")
+}
+
+var encryptCmd = &cobra.Command{
+	Use:   "encrypt [file path] [flags]",
+	Short: "Encrypt a Vault export file onto stdout or to an output file",
+	Long:  ``,
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		file := args[0]
+		publicKey, _ := cmd.Flags().GetString("public-key")
+		output, _ := cmd.Flags().GetString("output")
+
+		data, err := os.ReadFile(file)
+		if err != nil {
+			fmt.Println(err)
+			return err
+		}
+
+		encryptedKey, encryptedData := encrypt.Encrypt(publicKey, output, data)
+
+		if output == "" {
+			fmt.Println(string([]byte(encryptedData)))
+			fmt.Println(string(encryptedKey))
+		} else {
+			// Write to file
+			// First encrypted data
+			err = vaultengine.WriteToFile(output, []byte(encryptedData))
+			if err != nil {
+				return err
+			}
+			err = vaultengine.AppendStringToFile(output, "\n")
+			if err != nil {
+				return err
+			}
+			// Then encrypted AES key
+			err = vaultengine.AppendStringToFile(output, encryptedKey)
+			if err != nil {
+				return err
+			}
+			err = vaultengine.AppendStringToFile(output, "\n")
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	},
+}


### PR DESCRIPTION
This PR adds an `encrypt` subcommand that does the inverse of `decrypt`.

Our use case is that we want to use Medusa to export secrets, but we also are exporting our PKI private keys via `/sys/raw`. To keep things simple, we'd like one tool to be able to handle the encryption and decryption of all these files. There's already a subcommand to handle the decryption that works well, so we need a subcommand to do the encryption. (There's no expectation that Medusa will restore the stuff we exported from `/sys/raw`.)

Help:

```
$ .../medusa encrypt -h
Encrypt a Vault export file onto stdout or to an output file

Usage:
  medusa encrypt [file path] [flags]

Flags:
  -h, --help                help for encrypt
  -o, --output string       Write to file instead of stdout
  -p, --public-key string   Location of the RSA public key

Global Flags:
  -a, --address string     Address of the Vault server
  -k, --insecure           Allow insecure server connections when using SSL
  -n, --namespace string   Namespace within the Vault server (Enterprise only)
  -t, --token string       Vault authentication token
```

This goes back and forth nicely (FWIW this is a test only key and non sensitive data so no need to redact anything):

```
$ echo "Hello World" > payload.txt
$ .../medusa encrypt payload.txt --public-key public-key.pem --output payload.txt.b64
$ cat payload.txt.b64
7okDQwelUizUsndet4sTKpk3TzbBn6hiRW/G/jdHpTgULLvpovyx5Q==
WnlZY0NjajRESUhwTHI5YzN0dnZDV1FoUEVTc3ZCUFN3WEdXczZOMFlNaU9TWFFWYWwyTXI3eHNUYU8wYmEvaG55TGlwdUdCbWNpaWFBS0crYkxDbXAvd1FvTmFUMUcySmtGR3c1b2o3REMxZklRVU1HOElmaTFJb3FEbVJSKzdwL3VJZHY4Z0NmNnd5M3g2TE9mbFZkNnlWcVpNVDhoeE5OR2dPT0lYWTRVNkdlTjBIaWV1YlRoZ3A0TlpKUXZKc3ExUFhrOWc0YWNxQnZHU0V3VFZCOXhrdy9PS2ZKQklWVUI1N1hnemJJNXVrRmZia1I5MWJhWW1oKzlZbUIvdndUNXZsVXFIS1ppSmRTZWZzWExhaERGVGFwRyt4dExkUDhTYlFoUENCUXowRDV6K0NLdWlvOHZNNzd3WWlFSlV6NisxUCtmdjVCajJqaDdRQVhBVXhaRVk2NG04bDNSaDFEK1cxQ2Jvbi9wTHlGYkJCUnYyckk1VExER0p5VUNndWVhMFFRODVuVlEzanllK0YrVGdjb2lGenVENUswRmRXVk5mQXBWZTYvTWRmeDZkMVZvSTdBKzFPQlM4U0tSTjdzM0tkbUlVM2xMamcrZmIrSm5lSW9mM0ZpSHEwakpFeGtRV3NHRTBzNGFOYTJ0L21VUk5meGpUTnlZRE0wYm9xdkF4eFdlYlBxSE1vd00vR3hSMWpuNkRpL25MeVBLL0RtRnE4dFRlbEFvQXN4bnlXZHo5ZGdsQytDZG1UZXpnQS9HeFQrWnZRSnJtY2J5M1JoUTFGcFhTUElQOW9keVo1L09FTDZlVEZ0aTdicTFwOTJDRWpDeG1JdHIxaHRvSDVwRXhWT0xlMEZEcCtpckFqRmdEdm4rUnhMT3RzWGhZSjlhRGZPbkZ1SkE9
$ .../medusa decrypt payload.txt.b64 --private-key private-key.pem > payload.txt.new
$ cat payload.txt.new
Hello World
```

Implementation note: The output code added to `cmd/encrypt.go` is copy-pasta from:
https://github.com/jonasvinther/medusa/blob/578643a2693db0b033934f47eda5b551c5bedd09/cmd/export.go#L71-L97

I can DRY this if you prefer, but didn't want to go refactoring a bunch of stuff without a specific request to do so.