### PR TITLE
Allow authentication with Kubernetes JWT token

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,15 +302,23 @@ Usage:
   medusa [command]
 
 Available Commands:
+  completion  Generate the autocompletion script for the specified shell
+  decrypt     Decrypt an encrypted Vault output file into plaintext in stdout
+  delete      Recursively delete all secrets below the given path
+  encrypt     Encrypt a Vault export file onto stdout or to an output file
   export      Export Vault secrets as yaml
   help        Help about any command
   import      Import a yaml file into a Vault instance
+  version     Print the version number of Medusa
 
 Flags:
-  -a, --address string   Address of the Vault server
-  -h, --help             help for medusa
-  -k, --insecure         Allow insecure server connections when using SSL
-  -t, --token string     Vault authentication token
+  -a, --address string     Address of the Vault server
+  -h, --help               help for medusa
+  -k, --insecure           Allow insecure server connections when using SSL
+      --kubernetes         Authenticate using the Kubernetes JWT token
+  -n, --namespace string   Namespace within the Vault server (Enterprise only)
+  -r, --role string        Vault role for Kubernetes JWT authentication
+  -t, --token string       Vault authentication token
 
-Use "medusa [command] --help" for more information about a command.
+Use "medusa [command] --help" for more information about a command
 ``` 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -32,6 +32,24 @@ Created by Jonas Vinther & Henrik Høegh.`,
 			}
 		}
 
+		role, _ := cmd.Flags().GetString("role")
+		if viper.IsSet("VAULT_ROLE") && role == "" {
+			value := viper.Get("VAULT_ROLE").(string)
+			err := cmd.Flags().Set("role", value)
+			if err != nil {
+				return err
+			}
+		}
+
+		kubernetes, _ := cmd.Flags().GetBool("kubernetes")
+		if viper.IsSet("KUBERNETES") && kubernetes == false {
+			value := viper.GetBool("KUBERNETES")
+			err := cmd.Flags().Set("kubernetes", strconv.FormatBool(value))
+			if err != nil {
+				return err
+			}
+		}
+
 		insecure, _ := cmd.Flags().GetBool("insecure")
 		if viper.IsSet("VAULT_SKIP_VERIFY") && insecure == false {
 			value := viper.GetBool("VAULT_SKIP_VERIFY")
@@ -62,6 +80,8 @@ func Execute() error {
 func init() {
 	rootCmd.PersistentFlags().StringP("address", "a", "", "Address of the Vault server")
 	rootCmd.PersistentFlags().StringP("token", "t", "", "Vault authentication token")
+	rootCmd.PersistentFlags().StringP("role", "r", "", "Vault role for Kubernetes JWT authentication")
+	rootCmd.PersistentFlags().BoolP("kubernetes", "", false, "Authenticate using the Kubernetes JWT token")
 	rootCmd.PersistentFlags().BoolP("insecure", "k", false, "Allow insecure server connections when using SSL")
 	rootCmd.PersistentFlags().StringP("namespace", "n", "", "Namespace within the Vault server (Enterprise only)")
 

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -25,12 +25,14 @@ var deleteCmd = &cobra.Command{
 		vaultAddr, _ := cmd.Flags().GetString("address")
 		vaultToken, _ := cmd.Flags().GetString("token")
 		insecure, _ := cmd.Flags().GetBool("insecure")
+		vaultRole, _ := cmd.Flags().GetString("role")
+		kubernetes, _ := cmd.Flags().GetBool("kubernetes")
 		namespace, _ := cmd.Flags().GetString("namespace")
 		engineType, _ := cmd.Flags().GetString("engine-type")
 		isApproved, _ := cmd.Flags().GetBool("auto-approve")
 
 		// Setup Vault client
-		client := vaultengine.NewClient(vaultAddr, vaultToken, insecure, namespace)
+		client := vaultengine.NewClient(vaultAddr, vaultToken, insecure, namespace, vaultRole, kubernetes)
 		engine, path, err := client.MountpathSplitPrefix(path)
 		if err != nil {
 			fmt.Println(err)

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+
 	"github.com/jonasvinther/medusa/pkg/encrypt"
 	"github.com/jonasvinther/medusa/pkg/vaultengine"
 
@@ -27,6 +28,8 @@ var exportCmd = &cobra.Command{
 		path := args[0]
 		vaultAddr, _ := cmd.Flags().GetString("address")
 		vaultToken, _ := cmd.Flags().GetString("token")
+		vaultRole, _ := cmd.Flags().GetString("role")
+		kubernetes, _ := cmd.Flags().GetBool("kubernetes")
 		insecure, _ := cmd.Flags().GetBool("insecure")
 		namespace, _ := cmd.Flags().GetString("namespace")
 		engineType, _ := cmd.Flags().GetString("engine-type")
@@ -34,7 +37,7 @@ var exportCmd = &cobra.Command{
 		exportFormat, _ := cmd.Flags().GetString("format")
 		output, _ := cmd.Flags().GetString("output")
 
-		client := vaultengine.NewClient(vaultAddr, vaultToken, insecure, namespace)
+		client := vaultengine.NewClient(vaultAddr, vaultToken, insecure, namespace, vaultRole, kubernetes)
 		engine, path, err := client.MountpathSplitPrefix(path)
 		if err != nil {
 			fmt.Println(err)

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -31,12 +31,14 @@ var importCmd = &cobra.Command{
 		vaultAddr, _ := cmd.Flags().GetString("address")
 		vaultToken, _ := cmd.Flags().GetString("token")
 		insecure, _ := cmd.Flags().GetBool("insecure")
+		vaultRole, _ := cmd.Flags().GetString("role")
+		kubernetes, _ := cmd.Flags().GetBool("kubernetes")
 		namespace, _ := cmd.Flags().GetString("namespace")
 		engineType, _ := cmd.Flags().GetString("engine-type")
 		doDecrypt, _ := cmd.Flags().GetBool("decrypt")
 		privateKey, _ := cmd.Flags().GetString("private-key")
 
-		client := vaultengine.NewClient(vaultAddr, vaultToken, insecure, namespace)
+		client := vaultengine.NewClient(vaultAddr, vaultToken, insecure, namespace, vaultRole, kubernetes)
 		engine, prefix, err := client.MountpathSplitPrefix(path)
 		if err != nil {
 			fmt.Println(err)

--- a/docs/examples/kubernetes/cronjob/README.md
+++ b/docs/examples/kubernetes/cronjob/README.md
@@ -131,6 +131,13 @@ medusa-1615982100-5tfl8   0/1     Completed   0          60s
 medusa-1615982160-4b527   0/1     Completed   0          9s
 ```
 
+### Using Kubernetes authentication
+If you are using the kubernetes authentication method in Vault, it is also possible to use the kubernetes provided JWT token inside a Pod and auth role in order to authenticate.
+
+```yaml
+command: ["./medusa", "export", "$(VAULT_PATH)", "--kubernetes", "--role=default", "-o", "/backup/backup.vault"]
+```
+
 ### Further customization
 This only serves as an example as to how you could use `Medusa` to take a backup of Vault from a given location. 
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,8 @@ module github.com/jonasvinther/medusa
 go 1.13
 
 require (
-	github.com/hashicorp/vault/api v1.9.2
+	github.com/hashicorp/vault/api v1.10.0
+	github.com/hashicorp/vault/api/auth/kubernetes v0.5.0
 	github.com/manifoldco/promptui v0.9.0
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/viper v1.16.0

--- a/go.sum
+++ b/go.sum
@@ -869,8 +869,10 @@ github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO
 github.com/hashicorp/mdns v1.0.4/go.mod h1:mtBihi+LeNXGtG8L9dX59gAEa12BDtBQSp4v/YAJqrc=
 github.com/hashicorp/memberlist v0.5.0/go.mod h1:yvyXLpo0QaGE59Y7hDTsTzDD25JYBZ4mHgHUZ8lrOI0=
 github.com/hashicorp/serf v0.10.1/go.mod h1:yL2t6BqATOLGc5HF7qbFkTfXoPIY0WZdWHfEvMqbG+4=
-github.com/hashicorp/vault/api v1.9.2 h1:YjkZLJ7K3inKgMZ0wzCU9OHqc+UqMQyXsPXnf3Cl2as=
-github.com/hashicorp/vault/api v1.9.2/go.mod h1:jo5Y/ET+hNyz+JnKDt8XLAdKs+AM0G5W0Vp1IrFI8N8=
+github.com/hashicorp/vault/api v1.10.0 h1:/US7sIjWN6Imp4o/Rj1Ce2Nr5bki/AXi9vAW3p2tOJQ=
+github.com/hashicorp/vault/api v1.10.0/go.mod h1:jo5Y/ET+hNyz+JnKDt8XLAdKs+AM0G5W0Vp1IrFI8N8=
+github.com/hashicorp/vault/api/auth/kubernetes v0.5.0 h1:CXO0fD7M3iCGovP/UApeHhPcH4paDFKcu7AjEXi94rI=
+github.com/hashicorp/vault/api/auth/kubernetes v0.5.0/go.mod h1:afrElBIO9Q4sHFVuVWgNevG4uAs1bT2AZFA9aEiI608=
 github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=


### PR DESCRIPTION
This PR allows authentication using the Kubernetes JWT token located in `/var/run/secrets/kubernetes.io/serviceaccount/token` inside a Kubernetes pod.

My use case is that I have a cronjob to continuously backup vault, however I'd like to not store a Vault token as a Kubernetes secret and instead want to just rely on the Pods/ServiceAccounts JWT token to authenticate against vault.

I was able to test and verify things work as expected.