### PR TITLE
Change the vault image publisher to hashicorp

### DIFF
--- a/scripts/docker-compose-tls.yml
+++ b/scripts/docker-compose-tls.yml
@@ -1,7 +1,7 @@
 version: "3.8"
 services:
   vault:
-    image: vault:latest
+    image: hashicorp/vault:latest
     container_name: vault
     restart: on-failure:10
     ports:

--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.8"
 services:
   vault:
-    image: vault:latest
+    image: hashicorp/vault:latest
     container_name: vault
     restart: on-failure:10
     ports:

--- a/scripts/start-vault.sh
+++ b/scripts/start-vault.sh
@@ -53,9 +53,9 @@ docker run --network=container:vault --cap-add IPC_LOCK -e VAULT_ADDR=https://$V
 echo "
 To run vault commands, use the following docker command:
  - For connecting to Vault on the same Docker host:
-     docker run --network=container:vault --cap-add IPC_LOCK -e VAULT_ADDR=https://$VAULT_IP:8201 -e VAULT_SKIP_VERIFY=true --rm vault:latest vault status 
+     docker run --network=container:vault --cap-add IPC_LOCK -e VAULT_ADDR=https://$VAULT_IP:8201 -e VAULT_SKIP_VERIFY=true --rm hashicorp/vault:latest vault status 
  - For connecting to Vault from another host :
-     docker run --network=container:vault --cap-add IPC_LOCK -e VAULT_ADDR=https://$HOST_IP:8201 -e VAULT_SKIP_VERIFY=true --rm vault:latest vault status 
+     docker run --network=container:vault --cap-add IPC_LOCK -e VAULT_ADDR=https://$HOST_IP:8201 -e VAULT_SKIP_VERIFY=true --rm hashicorp/vault:latest vault status 
 "
 
 # Generate .env file


### PR DESCRIPTION
Hashicorp has deprecated the official Vault docker image and is now publishing new releases using their verified hashicorp docker account. 