### PR TITLE
Don't print error when attempting to read deleted secrets

### DIFF
--- a/pkg/vaultengine/secret_read.go
+++ b/pkg/vaultengine/secret_read.go
@@ -37,7 +37,8 @@ func (client *Client) SecretRead(path string) map[string]interface{} {
 		// of the secret has been deleted we return nil because there are
 		// no active version of the secret
 		metadata := secret.Data["metadata"].(map[string]interface{})
-		if metadata["destroyed"] == true {
+		if metadata["destroyed"] == true ||
+		   metadata["deleted"] != "" {
 			return nil
 		} else {
 			log.Printf("Error while reading secret\nPath:\t%s\nData:\t%#v\n\n", finalPath, secret.Data["data"])


### PR DESCRIPTION
Checks for non-empty "deleted" field on secret metadata if no data is returned from a kv read. This indicates that all versions of the secret have been deleted, so no error message should be produced.

Resolves [#134](https://github.com/jonasvinther/medusa/issues/134).