### PR TITLE
[fix] Add ssl certs to scratch image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN go get -d -v
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build \
     -ldflags="-X 'github.com/jonasvinther/medusa/cmd.Version=${VERSION}'" \
     -o /go/bin/medusa
+RUN apk add ca-certificates && update-ca-certificates
 
 RUN adduser -S scratchuser
 RUN chown scratchuser /go/bin/medusa
@@ -22,5 +23,7 @@ RUN chown scratchuser /go/bin/medusa
 FROM scratch
 COPY --from=builder /go/bin/medusa /medusa
 COPY --from=builder /etc/passwd /etc/passwd
+COPY --from=builder /usr/share/ca-certificates/mozilla/* /etc/ssl/certs/
+
 USER scratchuser
 ENTRYPOINT ["/medusa"]


### PR DESCRIPTION
Hi!

First of all, thanks for this tool, it's awesome and works pretty well!
I wanted to use the docker image just to create a containerized job to export credentials but i found that it was failing to verify the SSL cert. (using -k works)

```
 ✘ andres@andres-ThinkPad-E14-Gen-2  ~/workspace/forks/medusa   main  docker run -it -e "VAULT_ADDR=https://vault.example.com/" -e "VAULT_TOKEN=XXXXX" ghcr.io/jonasvinther/medusa:0.7.2 export common/alloy/
Get "https://vault.example.com/v1/sys/internal/ui/mounts/common/alloy": tls: failed to verify certificate: x509: certificate signed by unknown authority
Error: Get "https://vault.example.com/v1/sys/internal/ui/mounts/common/alloy": tls: failed to verify certificate: x509: certificate signed by unknown authority
Usage:
  medusa export [vault path] [flags]

Flags:
  -e, --encrypt              Encrypt the exported Vault data
  -m, --engine-type string   Specify the secret engine type [kv1|kv2] (default "kv2")
  -f, --format string        Specify the export format [yaml|json] (default "yaml")
  -h, --help                 help for export
  -o, --output string        Write to file instead of stdout
  -p, --public-key string    Location of the RSA public key

Global Flags:
  -a, --address string                Address of the Vault server
  -k, --insecure                      Allow insecure server connections when using SSL
      --kubernetes                    Authenticate using the Kubernetes JWT token
      --kubernetes-auth-path string   Authentication mount point within Vault for Kubernetes
  -n, --namespace string              Namespace within the Vault server (Enterprise only)
  -r, --role string                   Vault role for Kubernetes JWT authentication
  -t, --token string                  Vault authentication token

Get "https://vault.example.com/v1/sys/internal/ui/mounts/common/alloy": tls: failed to verify certificate: x509: certificate signed by unknown authority
```
* ignore the URL (i need to filter it for security reasons)

Looks like the scratch docker image where the go binaries are copied is pretty minimalist and it looks like it doesn't contain the system SSL certs.

I've modified the Dockerfile adding the certificates provided by the `ca-certificates` package from apk and now it looks like it can validate the SSL certificate and establish a secure connection.

Thanks again!